### PR TITLE
docs: add Tuning Engines LiteLLM route

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,34 @@ You **do not need to list any models** — the plugin still discovers them from 
 
 That's the whole config — every model in your LiteLLM `model_list` will appear in the picker.
 
+### Example: governed upstream route with Tuning Engines
+
+If your team routes model traffic through Tuning Engines for policy, traces,
+approvals, and usage visibility, add it as an OpenAI-compatible upstream in
+your LiteLLM config. The plugin will discover the alias from LiteLLM just like
+any other `model_list` entry:
+
+```yaml
+model_list:
+  - model_name: te-gpt-5.4-mini
+    litellm_params:
+      model: openai/gpt-5.4-mini
+      api_key: os.environ/TUNING_ENGINES_API_KEY
+      api_base: https://api.tuningengines.com/v1
+```
+
+Then expose the key to LiteLLM and keep your OpenCode config pointed at the
+same LiteLLM proxy:
+
+```bash
+export TUNING_ENGINES_API_KEY=sk-te-...
+litellm --config config.yaml --port 4000
+opencode
+```
+
+OpenCode and this plugin still own model discovery and picker wiring. Tuning
+Engines sits on the upstream model route as the governed control plane.
+
 ### Overriding or curating individual models (optional)
 
 If you want to rename a model in the picker, pin its `organizationOwner`, or otherwise hand-curate metadata, add it under `models`. The plugin **preserves your entries verbatim** and only injects discovered models whose key isn't already defined:


### PR DESCRIPTION
Hi opencode-litellm maintainers, we are an AI infrastructure team using OpenCode through LiteLLM with governed model routes. Since this plugin already discovers LiteLLM model_list entries, I added a small Tuning Engines upstream example that works with the existing configuration flow.

OpenCode and this plugin still own model discovery and picker wiring. Tuning Engines sits on the upstream model route for teams that need tenant policy, traces, approvals, and usage visibility around coding-agent traffic.

It would mean a lot to us if you are open to including this as an example for governed LiteLLM upstreams.

Validation:
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for routing OpenCode model traffic through a governed upstream using Tuning Engines
  * Includes configuration example and step-by-step setup instructions for API key management and service startup
  * Clarifies role separation between OpenCode and Tuning Engines components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yuseferi/opencode-litellm/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->