### PR TITLE
feat(auth)!: SDK-native auth via /connect flow, auth.loader, and provider.models hook

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -1,0 +1,22 @@
+# Copy this file to .env and fill in your values.
+# .env is gitignored — never commit it.
+#
+# ── Tailscale ephemeral auth key ──────────────────────────────────────────────
+#
+# Create one at: https://login.tailscale.com/admin/settings/keys
+#   → Generate auth key
+#   → Reusable:       ✓  (so multiple container starts use the same key)
+#   → Ephemeral:      ✓  (node auto-removed from tailnet when container stops)
+#   → Pre-authorized: ✓  (skips manual device approval)
+#   → Expiry:         90 days (or your preferred duration)
+#
+# When the key expires, generate a new one and update this file.
+# ─────────────────────────────────────────────────────────────────────────────
+
+TS_AUTHKEY=tskey-auth-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx
+
+# LiteLLM proxy URL on your tailnet
+LITELLM_URL=http://100.121.176.43:4000
+
+# LiteLLM master key (injected into the container's isolated auth store)
+LITELLM_API_KEY=sk-your-master-key-here

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:22-slim
+
+# Install minimal system deps
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      git \
+      ca-certificates \
+      curl \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install pinned opencode CLI. The linux-arm64 optional dep resolves
+# automatically because npm honours cpu/os fields.
+RUN npm install -g opencode-ai@1.17.1 \
+ && opencode --version
+
+# Terminal settings needed for TUI rendering
+ENV TERM=xterm-256color \
+    COLORTERM=truecolor \
+    OPENCODE_CONFIG_DIR=/root/.config/opencode \
+    OPENCODE_DATA_DIR=/root/.local/share/opencode
+
+WORKDIR /work
+
+# Copy helper scripts so they are baked into the image
+COPY entrypoint.sh /usr/local/bin/entrypoint
+COPY smoke.sh      /usr/local/bin/smoke
+RUN chmod +x /usr/local/bin/entrypoint /usr/local/bin/smoke
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+CMD ["bash"]

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,113 @@
+# Dev Container — opencode-litellm
+
+Isolated Docker environment for testing the opencode-litellm plugin without
+touching your host opencode config or auth files.
+
+## Prerequisites
+
+- Docker Desktop running
+- A Tailscale ephemeral auth key (for tailnet access to your LiteLLM proxy)
+
+## One-time setup
+
+### 1. Generate a Tailscale ephemeral auth key
+
+Go to `https://login.tailscale.com/admin/settings/keys` and click
+**Generate auth key** with these settings:
+
+| Setting | Value |
+|---|---|
+| Reusable | ✓ checked (same key works across container restarts) |
+| Ephemeral | ✓ checked (node auto-removed from tailnet on container stop) |
+| Pre-authorized | ✓ checked (no manual device approval needed) |
+| Expiry | 90 days (or your preference — regenerate when it expires) |
+
+Copy the key (`tskey-auth-...`). No ACL changes required.
+
+### 2. Create `.env`
+
+```bash
+cp .devcontainer/.env.example .devcontainer/.env
+# edit .env — set TS_AUTHKEY, LITELLM_API_KEY
+```
+
+### 3. Build the image
+
+```bash
+cd .devcontainer
+docker compose build
+```
+
+Takes ~90 s on first run (installs opencode-ai@1.17.1). Subsequent builds use
+the layer cache and are instant unless the Dockerfile changes.
+
+## Running
+
+All commands are run from the `.devcontainer/` directory.
+
+### Headless smoke test (exits 0 on pass, non-zero on fail)
+
+```bash
+docker compose --profile smoke run --rm smoke
+```
+
+Use this as the pre-commit / CI gate. It:
+- Starts the Tailscale sidecar (ephemeral node)
+- Waits for the LiteLLM proxy to be reachable
+- Runs the 3-hook assertion script against the plugin source
+- Prints PASS/FAIL per assertion and exits accordingly
+
+### Full interactive TUI
+
+```bash
+docker compose --profile tui run --rm tui
+```
+
+Opens opencode in your terminal. The container's isolated `auth.json` is
+pre-seeded with `LITELLM_API_KEY` from `.env`.
+
+### Interactive shell
+
+```bash
+docker compose --profile shell run --rm shell
+```
+
+Drops you into bash inside the container. Useful for ad-hoc testing.
+`/work` is the repo root, live-mounted read-write.
+
+## State isolation
+
+| Volume | Maps to | Purpose |
+|---|---|---|
+| `opencode-state` | `/root/.local/share/opencode` | Isolated auth.json, session data |
+| `opencode-config` | `/root/.config/opencode` | Isolated opencode.jsonc |
+| `tailscale-state` | `/var/lib/tailscale` | Tailscale machine key (ephemeral) |
+
+Your **host** `~/.config/opencode/` and `~/.local/share/opencode/` are never
+mounted and are never modified.
+
+## Reset all state
+
+```bash
+docker compose down -v
+```
+
+Removes all named volumes. Next `run` starts completely fresh — new Tailscale
+node registration, empty auth.json, empty config.
+
+## Troubleshooting
+
+**LiteLLM proxy unreachable after 30 s**
+The entrypoint will warn and continue. The smoke test will still run but
+`provider.models` may throw (treated as a pass for hook-wiring purposes when
+the server is unreachable). Check that Tailscale is connected and the proxy
+is running on your tailnet.
+
+**opencode TUI renders garbled**
+Run from a proper terminal emulator (not a raw pipe). If using iTerm2 / macOS
+Terminal it should work cleanly. Tmux users: ensure `$TERM` is set to
+`xterm-256color` in the host before launching compose.
+
+**`TS_OAUTH_CLIENT_ID` / `TS_OAUTH_CLIENT_SECRET` errors**
+These are required. Double-check `.env` exists in `.devcontainer/` and contains
+both values (not the placeholder text from `.env.example`).

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,0 +1,84 @@
+name: opencode-litellm-dev
+
+# ── Tailscale auth ────────────────────────────────────────────────────────────
+# Uses a reusable ephemeral auth key (TS_AUTHKEY).
+#
+# Create one at: https://login.tailscale.com/admin/settings/keys
+#   - Type: Reusable
+#   - Expiry: your preferred duration (e.g. 90 days)
+#   - Ephemeral: ✓ checked  (node auto-removed from tailnet on container stop)
+#   - Pre-authorized: ✓ checked
+#
+# The ?ephemeral=true suffix below ensures the node is removed immediately
+# when the container stops, even if the key itself is still valid.
+# No ACL tag changes needed.
+# ─────────────────────────────────────────────────────────────────────────────
+
+services:
+
+  # ── Tailscale network sidecar ─────────────────────────────────────────────
+  tailscale:
+    image: tailscale/tailscale:stable
+    hostname: opencode-litellm-test
+    environment:
+      # Append ?ephemeral=true so the node is auto-removed on container stop.
+      TS_AUTHKEY: "${TS_AUTHKEY:?set TS_AUTHKEY in .devcontainer/.env}?ephemeral=true"
+      TS_EXTRA_ARGS: "--accept-routes"
+      # TS_USERSPACE=true: Docker Desktop on Mac doesn't expose /dev/net/tun.
+      TS_USERSPACE: "true"
+      # No state persistence — ephemeral nodes register fresh on every start.
+      TS_STATE_DIR: /tmp/tailscale-state
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    restart: "no"
+
+  # ── Base service (shell, smoke, tui all extend this) ──────────────────────
+  oc-base:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      - tailscale
+    network_mode: "service:tailscale"
+    environment:
+      LITELLM_URL: ${LITELLM_URL:-http://100.121.176.43:4000}
+      LITELLM_API_KEY: ${LITELLM_API_KEY:-}
+    volumes:
+      - ../:/work
+      - opencode-state:/root/.local/share/opencode
+      - opencode-config:/root/.config/opencode
+    working_dir: /work
+    tty: true
+    stdin_open: true
+    profiles: ["_base"]  # never started directly
+
+  # ── Shell — interactive bash ───────────────────────────────────────────────
+  shell:
+    extends:
+      service: oc-base
+    profiles: ["shell"]
+    command: ["bash"]
+
+  # ── Smoke — headless hook assertions, exits 0 or non-zero ─────────────────
+  # Smoke tests exercise hook wiring only (no live proxy needed).
+  # SKIP_TS_WAIT=1 bypasses the 30 s Tailscale readiness poll.
+  smoke:
+    extends:
+      service: oc-base
+    profiles: ["smoke"]
+    tty: false
+    environment:
+      SKIP_TS_WAIT: "1"
+    command: ["smoke"]
+
+  # ── TUI — full interactive opencode ───────────────────────────────────────
+  tui:
+    extends:
+      service: oc-base
+    profiles: ["tui"]
+    command: ["opencode"]
+
+volumes:
+  opencode-state:
+  opencode-config:

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# entrypoint.sh — runs inside the oc container before the main command.
+#
+# Responsibilities:
+#   1. Wait for the Tailscale sidecar to come online (shared network namespace).
+#   2. Install plugin dependencies if not already present (node_modules).
+#   3. Exec the user command (bash / smoke / opencode).
+set -euo pipefail
+
+# ── 1. Wait for Tailscale ─────────────────────────────────────────────────────
+# The sidecar shares our network namespace; tailscale CLI is not present here,
+# but we can detect readiness by polling the tailscaled socket status file or
+# simply checking connectivity to the LiteLLM proxy once it's reachable.
+#
+# Simplest reliable approach: wait for the Tailscale state dir to contain a
+# non-empty machine key file (written by the sidecar after registration).
+
+TAILSCALE_STATE_DIR="${TAILSCALE_STATE_DIR:-/var/lib/tailscale}"
+LITELLM_URL="${LITELLM_URL:-http://100.121.176.43:4000}"
+MAX_WAIT=${TS_WAIT_TIMEOUT:-30}
+WAITED=0
+
+# Skip Tailscale wait entirely if SKIP_TS_WAIT is set (useful for unit tests
+# and CI builds that don't need tailnet access).
+if [ "${SKIP_TS_WAIT:-}" != "1" ]; then
+  echo "[entrypoint] waiting for Tailscale to come online (max ${MAX_WAIT}s)..."
+  while true; do
+    if curl -sf --max-time 2 "${LITELLM_URL}/health" > /dev/null 2>&1; then
+      echo "[entrypoint] Tailscale ready — LiteLLM proxy reachable at ${LITELLM_URL}"
+      break
+    fi
+    if [ "${WAITED}" -ge "${MAX_WAIT}" ]; then
+      echo "[entrypoint] WARNING: LiteLLM proxy unreachable after ${MAX_WAIT}s — continuing anyway"
+      break
+    fi
+    sleep 1
+    WAITED=$((WAITED + 1))
+  done
+fi
+
+# ── 2. Auto-install plugin deps ───────────────────────────────────────────────
+if [ -f "/work/package.json" ] && [ ! -d "/work/node_modules" ]; then
+  echo "[entrypoint] installing plugin dependencies..."
+  npm install --prefix /work
+fi
+
+# ── 3. Exec the requested command ─────────────────────────────────────────────
+exec "$@"

--- a/.devcontainer/smoke.sh
+++ b/.devcontainer/smoke.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# smoke.sh — headless 3-hook assertion test for the opencode-litellm plugin.
+#
+# Exit codes:
+#   0  all assertions passed
+#   1  one or more assertions failed
+#
+# Designed to run inside the devcontainer (invoked by `docker compose run smoke`).
+set -euo pipefail
+
+SMOKE_DIR="/tmp/litellm-smoke-$$"
+SENTINEL_KEY="sk-smoke-sentinel"
+LITELLM_URL="${LITELLM_URL:-http://100.121.176.43:4000}"
+PASS=0
+FAIL=0
+
+cleanup() {
+  rm -rf "${SMOKE_DIR}"
+}
+trap cleanup EXIT
+
+echo "[smoke] ── opencode-litellm hook smoke test ──────────────────────────"
+echo "[smoke] sentinel key : ${SENTINEL_KEY}"
+echo "[smoke] litellm url  : ${LITELLM_URL}"
+echo ""
+
+# ── Resolve plugin entry point ────────────────────────────────────────────────
+PLUGIN_ENTRY="$(node -e "console.log(require.resolve('/work/src/plugin/index.ts', { paths: ['/work'] }))" 2>/dev/null || true)"
+if [ -z "${PLUGIN_ENTRY}" ]; then
+  # Fall back to compiled output if TypeScript source isn't directly resolvable
+  PLUGIN_ENTRY="/work/src/plugin/index.ts"
+fi
+
+# ── Locate @opencode-ai/plugin SDK ───────────────────────────────────────────
+SDK_PATH="$(node -e "console.log(require.resolve('@opencode-ai/plugin', { paths: ['/work/node_modules', '/work'] }))" 2>/dev/null || echo "")"
+if [ -z "${SDK_PATH}" ]; then
+  echo "[smoke] ERROR: @opencode-ai/plugin not found in /work/node_modules"
+  exit 1
+fi
+SDK_DIR="$(dirname "${SDK_PATH}")"
+
+mkdir -p "${SMOKE_DIR}"
+
+# ── Write isolated opencode config (no real server; port 1 is always closed) ──
+cat > "${SMOKE_DIR}/opencode.json" <<EOF
+{
+  "providers": {
+    "litellm": {
+      "name": "LiteLLM",
+      "baseURL": "http://127.0.0.1:1/v1"
+    }
+  }
+}
+EOF
+
+# ── Write isolated auth.json with sentinel key ────────────────────────────────
+AUTH_DIR="${SMOKE_DIR}/opencode-data"
+mkdir -p "${AUTH_DIR}"
+cat > "${AUTH_DIR}/auth.json" <<EOF
+{
+  "providers": {
+    "litellm": {
+      "type": "api",
+      "key": "${SENTINEL_KEY}"
+    }
+  }
+}
+EOF
+
+# ── Write standalone hook-invocation script ───────────────────────────────────
+cat > "${SMOKE_DIR}/run-hooks.mjs" <<'SCRIPT'
+import { readFileSync } from "fs"
+import { pathToFileURL } from "url"
+import process from "process"
+
+const SENTINEL = "sk-smoke-sentinel"
+const smokeDir = process.env.SMOKE_DIR
+const workDir  = process.env.WORK_DIR
+const authFile = `${smokeDir}/opencode-data/auth.json`
+
+// Load auth.json so we can construct an Auth object
+const authJson = JSON.parse(readFileSync(authFile, "utf8"))
+const litellmAuth = authJson.providers?.litellm ?? null
+
+const ctx = litellmAuth
+  ? { auth: { type: litellmAuth.type, key: litellmAuth.key } }
+  : {}
+
+// Dynamically import the plugin (TypeScript via --experimental-strip-types)
+const pluginUrl = pathToFileURL(`${workDir}/src/plugin/index.ts`).href
+const pluginModule = await import(pluginUrl)
+const plugin = pluginModule.default ?? pluginModule
+
+let passed = 0
+let failed = 0
+
+function assert(label, value) {
+  if (value) {
+    console.log(`[smoke] PASS: ${label}`)
+    passed++
+  } else {
+    console.error(`[smoke] FAIL: ${label}`)
+    failed++
+  }
+}
+
+// ── Hook 1: config ────────────────────────────────────────────────────────────
+try {
+  const configHook = plugin?.hooks?.config
+  if (typeof configHook === "function") {
+    const result = await configHook({})
+    assert("1/3 config hook fires and returns an object", result && typeof result === "object")
+    console.log("[smoke] config result:", JSON.stringify(result, null, 2))
+  } else {
+    assert("1/3 config hook exists", false)
+  }
+} catch (e) {
+  console.error("[smoke] config hook threw:", e.message)
+  failed++
+}
+
+// ── Hook 2: auth.loader ───────────────────────────────────────────────────────
+try {
+  const authLoader = plugin?.hooks?.auth?.loader
+  if (typeof authLoader === "function") {
+    const result = await authLoader({})
+    const keyMatch = result?.key === SENTINEL
+    assert("2/3 auth.loader fires and returns sentinel key", keyMatch)
+    console.log("[smoke] auth.loader result:", JSON.stringify(result, null, 2))
+  } else {
+    // auth.loader is optional (added in this PR) — skip gracefully
+    console.log("[smoke] INFO: auth.loader hook not present (expected before PR lands)")
+    passed++
+  }
+} catch (e) {
+  console.error("[smoke] auth.loader hook threw:", e.message)
+  failed++
+}
+
+// ── Hook 3: provider.models ───────────────────────────────────────────────────
+try {
+  const modelsHook = plugin?.hooks?.provider?.models
+  if (typeof modelsHook === "function") {
+    const result = await modelsHook(ctx)
+    const hasSentinel = result && typeof result === "object" && Object.keys(result).length > 0
+    assert("3/3 provider.models fires and returns model map", hasSentinel)
+    if (ctx.auth) {
+      const keyMatch = ctx.auth.key === SENTINEL
+      assert("3/3 provider.models received sentinel key in ctx.auth", keyMatch)
+    }
+    console.log("[smoke] provider.models returned", Object.keys(result ?? {}).length, "models")
+  } else {
+    assert("3/3 provider.models hook exists", false)
+  }
+} catch (e) {
+  // Benign if server is unreachable (port 1) — model list may fail
+  console.log("[smoke] provider.models threw (may be expected — no real server):", e.message)
+  passed++ // treat unreachable-server as pass for hook-wiring purposes
+}
+
+console.log("")
+console.log(`[smoke] results: ${passed} passed, ${failed} failed`)
+process.exit(failed > 0 ? 1 : 0)
+SCRIPT
+
+# ── Run the hook script ───────────────────────────────────────────────────────
+echo "[smoke] running hook assertions..."
+echo ""
+
+SMOKE_DIR="${SMOKE_DIR}" \
+WORK_DIR="/work" \
+OPENCODE_CONFIG_DIR="${SMOKE_DIR}" \
+OPENCODE_DATA_DIR="${SMOKE_DIR}/opencode-data" \
+  node \
+    --experimental-strip-types \
+    --experimental-vm-modules \
+    --no-warnings \
+    "${SMOKE_DIR}/run-hooks.mjs"
+
+STATUS=$?
+
+echo ""
+if [ "${STATUS}" -eq 0 ]; then
+  echo "[smoke] ── ALL ASSERTIONS PASSED ✓ ─────────────────────────────────"
+else
+  echo "[smoke] ── SOME ASSERTIONS FAILED ✗ ────────────────────────────────"
+fi
+
+exit "${STATUS}"

--- a/.devcontainer/smoke.sh
+++ b/.devcontainer/smoke.sh
@@ -25,14 +25,16 @@ echo "[smoke] litellm url  : ${LITELLM_URL}"
 echo ""
 
 # ── Resolve plugin entry point ────────────────────────────────────────────────
-PLUGIN_ENTRY="$(node -e "console.log(require.resolve('/work/src/plugin/index.ts', { paths: ['/work'] }))" 2>/dev/null || true)"
-if [ -z "${PLUGIN_ENTRY}" ]; then
-  # Fall back to compiled output if TypeScript source isn't directly resolvable
-  PLUGIN_ENTRY="/work/src/plugin/index.ts"
-fi
+# Source is always at a known path — no resolution needed.
+PLUGIN_ENTRY="/work/src/plugin/index.ts"
 
 # ── Locate @opencode-ai/plugin SDK ───────────────────────────────────────────
-SDK_PATH="$(node -e "console.log(require.resolve('@opencode-ai/plugin', { paths: ['/work/node_modules', '/work'] }))" 2>/dev/null || echo "")"
+# The package uses an exports map; resolve via a script colocated in /work
+# so Node's module resolution walks up from there and finds node_modules.
+_RESOLVE_SCRIPT="/work/_smoke_resolve.mjs"
+printf 'console.log(new URL(await import.meta.resolve("@opencode-ai/plugin")).pathname)\n' > "${_RESOLVE_SCRIPT}"
+SDK_PATH="$(node --no-warnings "${_RESOLVE_SCRIPT}" 2>/dev/null || echo "")"
+rm -f "${_RESOLVE_SCRIPT}"
 if [ -z "${SDK_PATH}" ]; then
   echo "[smoke] ERROR: @opencode-ai/plugin not found in /work/node_modules"
   exit 1
@@ -68,33 +70,31 @@ cat > "${AUTH_DIR}/auth.json" <<EOF
 EOF
 
 # ── Write standalone hook-invocation script ───────────────────────────────────
-cat > "${SMOKE_DIR}/run-hooks.mjs" <<'SCRIPT'
+cat > "${SMOKE_DIR}/run-hooks.mts" <<'SCRIPT'
 import { readFileSync } from "fs"
 import { pathToFileURL } from "url"
 import process from "process"
+import type { Auth } from "@opencode-ai/sdk/v2"
 
 const SENTINEL = "sk-smoke-sentinel"
-const smokeDir = process.env.SMOKE_DIR
-const workDir  = process.env.WORK_DIR
-const authFile = `${smokeDir}/opencode-data/auth.json`
+const smokeDir = process.env.SMOKE_DIR!
+const workDir  = process.env.WORK_DIR!
 
-// Load auth.json so we can construct an Auth object
-const authJson = JSON.parse(readFileSync(authFile, "utf8"))
-const litellmAuth = authJson.providers?.litellm ?? null
+// Simulate stored auth: getAuth() returns the sentinel key
+const getAuth = async (): Promise<Auth> =>
+  ({ type: "api", key: SENTINEL } as Auth)
 
-const ctx = litellmAuth
-  ? { auth: { type: litellmAuth.type, key: litellmAuth.key } }
-  : {}
+// ctx passed to provider.models hook
+const ctx = { auth: { type: "api" as const, key: SENTINEL } }
 
-// Dynamically import the plugin (TypeScript via --experimental-strip-types)
-const pluginUrl = pathToFileURL(`${workDir}/src/plugin/index.ts`).href
-const pluginModule = await import(pluginUrl)
-const plugin = pluginModule.default ?? pluginModule
+// Load the plugin and invoke it (PluginInput can be empty for smoke)
+const pluginModule = await import(pathToFileURL(`${workDir}/src/plugin/index.ts`).href)
+const hooks = await pluginModule.LiteLLMPlugin({} as any)
 
 let passed = 0
 let failed = 0
 
-function assert(label, value) {
+function assert(label: string, value: unknown) {
   if (value) {
     console.log(`[smoke] PASS: ${label}`)
     passed++
@@ -105,57 +105,60 @@ function assert(label, value) {
 }
 
 // ── Hook 1: config ────────────────────────────────────────────────────────────
+// config modifies its argument in-place and returns void — check it doesn't throw.
 try {
-  const configHook = plugin?.hooks?.config
-  if (typeof configHook === "function") {
-    const result = await configHook({})
-    assert("1/3 config hook fires and returns an object", result && typeof result === "object")
-    console.log("[smoke] config result:", JSON.stringify(result, null, 2))
-  } else {
-    assert("1/3 config hook exists", false)
+  assert("1/3 config hook is a function", typeof hooks.config === "function")
+  if (typeof hooks.config === "function") {
+    const cfg: any = {}
+    await hooks.config(cfg)
+    // After calling with empty config and no reachable proxy, provider may be
+    // absent — that's fine. We just assert the hook didn't throw.
+    console.log("[smoke] config ran without throwing ✓")
   }
-} catch (e) {
+} catch (e: any) {
   console.error("[smoke] config hook threw:", e.message)
   failed++
 }
 
-// ── Hook 2: auth.loader ───────────────────────────────────────────────────────
+// ── Hook 2: auth.loader ────────────────────────────────────────────────────────
+// auth.loader receives a getAuth callback and should return { apiKey: SENTINEL }
 try {
-  const authLoader = plugin?.hooks?.auth?.loader
-  if (typeof authLoader === "function") {
-    const result = await authLoader({})
-    const keyMatch = result?.key === SENTINEL
-    assert("2/3 auth.loader fires and returns sentinel key", keyMatch)
-    console.log("[smoke] auth.loader result:", JSON.stringify(result, null, 2))
-  } else {
-    // auth.loader is optional (added in this PR) — skip gracefully
-    console.log("[smoke] INFO: auth.loader hook not present (expected before PR lands)")
-    passed++
+  const loader = hooks.auth?.loader
+  assert("2/3 auth.loader hook is present", typeof loader === "function")
+  if (typeof loader === "function") {
+    const result = await loader(getAuth, {} as any)
+    const keyMatch = (result as any)?.apiKey === SENTINEL
+    assert("2/3 auth.loader returns { apiKey: sentinel }", keyMatch)
+    console.log("[smoke] auth.loader result:", JSON.stringify(result))
   }
-} catch (e) {
-  console.error("[smoke] auth.loader hook threw:", e.message)
+} catch (e: any) {
+  console.error("[smoke] auth.loader threw:", e.message)
   failed++
 }
 
 // ── Hook 3: provider.models ───────────────────────────────────────────────────
+// provider.models receives (provider, ctx) — ctx.auth carries the sentinel key.
+// The proxy is unreachable in the container so discovery will return {}.
+// We assert: (a) hook exists, (b) it accepts ctx.auth without crashing.
 try {
-  const modelsHook = plugin?.hooks?.provider?.models
+  const modelsHook = hooks.provider?.models
+  assert("3/3 provider.models hook is present", typeof modelsHook === "function")
   if (typeof modelsHook === "function") {
-    const result = await modelsHook(ctx)
-    const hasSentinel = result && typeof result === "object" && Object.keys(result).length > 0
-    assert("3/3 provider.models fires and returns model map", hasSentinel)
-    if (ctx.auth) {
-      const keyMatch = ctx.auth.key === SENTINEL
-      assert("3/3 provider.models received sentinel key in ctx.auth", keyMatch)
+    // Minimal provider shape with a baseURL that won't resolve (port 1)
+    const fakeProvider = {
+      id: "litellm",
+      name: "LiteLLM",
+      options: { baseURL: "http://127.0.0.1:1/v1", apiKey: SENTINEL },
     }
-    console.log("[smoke] provider.models returned", Object.keys(result ?? {}).length, "models")
-  } else {
-    assert("3/3 provider.models hook exists", false)
+    const result = await modelsHook(fakeProvider as any, ctx)
+    // Result is {} because port 1 is unreachable — that's expected
+    assert("3/3 provider.models executed with ctx.auth (unreachable proxy → {} is ok)",
+      result !== undefined && typeof result === "object")
+    console.log("[smoke] provider.models returned", Object.keys(result ?? {}).length, "models (0 expected — no proxy)")
   }
-} catch (e) {
-  // Benign if server is unreachable (port 1) — model list may fail
-  console.log("[smoke] provider.models threw (may be expected — no real server):", e.message)
-  passed++ // treat unreachable-server as pass for hook-wiring purposes
+} catch (e: any) {
+  console.error("[smoke] provider.models threw unexpectedly:", e.message)
+  failed++
 }
 
 console.log("")
@@ -171,11 +174,8 @@ SMOKE_DIR="${SMOKE_DIR}" \
 WORK_DIR="/work" \
 OPENCODE_CONFIG_DIR="${SMOKE_DIR}" \
 OPENCODE_DATA_DIR="${SMOKE_DIR}/opencode-data" \
-  node \
-    --experimental-strip-types \
-    --experimental-vm-modules \
-    --no-warnings \
-    "${SMOKE_DIR}/run-hooks.mjs"
+  /work/node_modules/.bin/tsx \
+    "${SMOKE_DIR}/run-hooks.mts"
 
 STATUS=$?
 

--- a/.github/SMOKE_TEST.md
+++ b/.github/SMOKE_TEST.md
@@ -1,0 +1,217 @@
+# Smoke test: SDK-native auth resolution
+
+Pre-PR gate for `feat/sdk-native-auth`. Verifies that OpenCode ≥ 1.14.50
+delivers stored credentials to the plugin via `Hooks.auth.loader` and
+`Hooks.provider.models` with a non-null `ctx.auth`, which is the runtime
+precondition for [ADR 0001](../docs/decisions/0001-sdk-native-auth.md).
+
+**The PR is opened only after this test passes.**
+
+---
+
+## Prerequisites
+
+| Requirement | Check |
+|---|---|
+| OpenCode ≥ 1.14.50 on `$PATH` | `opencode --version` |
+| Node.js ≥ 20 or Bun ≥ 1.0 | `node --version` or `bun --version` |
+| ~5 minutes | |
+
+### Building opencode from source (if needed)
+
+```sh
+git clone https://github.com/anomalyco/opencode /tmp/opencode-smoke
+cd /tmp/opencode-smoke
+git fetch --tags
+git checkout $(git tag -l 'v1.14.*' | sort -V | tail -1)
+bun install
+# confirm version
+bun packages/opencode/src/index.ts --version
+```
+
+Add an alias so the smoke test can call it:
+
+```sh
+alias opencode="bun /tmp/opencode-smoke/packages/opencode/src/index.ts"
+```
+
+---
+
+## Setup
+
+Create an isolated scratch directory:
+
+```sh
+mkdir -p /tmp/litellm-smoke && cd /tmp/litellm-smoke
+```
+
+### `opencode.json`
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["./test-plugin.ts"],
+  "provider": {
+    "litellm": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "baseURL": "http://127.0.0.1:1/v1"
+      }
+    }
+  }
+}
+```
+
+> `baseURL` points at a closed port intentionally. The smoke test does not
+> require a running LiteLLM proxy — it only verifies the hook lifecycle and
+> credential delivery, not network reachability.
+
+### `test-plugin.ts`
+
+```ts
+import type { Plugin } from '@opencode-ai/plugin'
+
+export const Smoke: Plugin = async () => ({
+  config: async () => {
+    console.log('[smoke] 1/3 config FIRED')
+  },
+
+  auth: {
+    provider: 'litellm',
+    methods: [
+      {
+        type: 'api',
+        label: 'API key',
+        prompts: [
+          {
+            type: 'text',
+            key: 'key',
+            message: 'LiteLLM master key',
+            placeholder: 'sk-…',
+          },
+        ],
+      },
+    ],
+    loader: async (getAuth) => {
+      const stored = await getAuth()
+      console.log('[smoke] 2/3 auth.loader FIRED', {
+        hasAuth: !!stored,
+        type: stored?.type ?? 'none',
+        keyMatchesSentinel:
+          stored?.type === 'api' && stored.key === 'sk-smoke-sentinel',
+      })
+      if (stored?.type !== 'api' || !stored.key) return {}
+      return { apiKey: stored.key }
+    },
+  },
+
+  provider: {
+    id: 'litellm',
+    models: async (_provider, ctx) => {
+      console.log('[smoke] 3/3 provider.models FIRED', {
+        hasCtxAuth: !!ctx.auth,
+        ctxAuthType: ctx.auth?.type ?? 'none',
+        keyMatchesSentinel:
+          ctx.auth?.type === 'api' && ctx.auth.key === 'sk-smoke-sentinel',
+      })
+      return {
+        'sentinel-model': {
+          id: 'sentinel-model',
+          name: 'SMOKE TEST SENTINEL — safe to delete',
+        } as any,
+      }
+    },
+  },
+})
+```
+
+---
+
+## Run
+
+### Step 1 — Store a sentinel key
+
+```sh
+opencode providers add litellm
+```
+
+When prompted, paste exactly:
+
+```
+sk-smoke-sentinel
+```
+
+### Step 2 — Start OpenCode in the scratch directory
+
+```sh
+cd /tmp/litellm-smoke
+opencode
+```
+
+Watch stdout for the three `[smoke]` lines.
+
+### Step 3 — Check the model picker
+
+Open the model picker (`/models` or the keybind). Confirm
+`SMOKE TEST SENTINEL — safe to delete` appears under the `litellm`
+provider.
+
+### Step 4 — Quit and clean up
+
+```sh
+# Remove the sentinel key from the credential store
+opencode providers remove litellm   # or delete from auth.json manually
+rm -rf /tmp/litellm-smoke
+```
+
+---
+
+## Pass criteria
+
+All four must be true. Check each box before opening the PR:
+
+- [ ] `[smoke] 1/3 config FIRED` appears in stdout.
+- [ ] `[smoke] 2/3 auth.loader FIRED` appears with `type: "api"` and
+      `keyMatchesSentinel: true`.
+- [ ] `[smoke] 3/3 provider.models FIRED` appears with `hasCtxAuth: true`,
+      `ctxAuthType: "api"`, and `keyMatchesSentinel: true`.
+- [ ] `SMOKE TEST SENTINEL` is selectable in the model picker under `litellm`.
+
+Expected order: `config → auth.loader → provider.models`. The loader and
+provider hook may interleave depending on OpenCode internals, but all three
+must fire and config must be first.
+
+---
+
+## Failure modes and contingencies
+
+| Symptom | Interpretation | Action |
+|---|---|---|
+| `provider.models` line never appears | Custom-provider `Hooks.provider` not called by this opencode version | Drop Option B from ADR 0001; ship Option A (`auth.loader`) only; update ADR status; file upstream issue against `anomalyco/opencode` |
+| `provider.models` fires but `hasCtxAuth: false` | Core does not populate `ctx.auth` for this provider id | Same as above |
+| `keyMatchesSentinel: false` in loader or ctx | Key stored under wrong id or wrong shape | Re-run `opencode providers add litellm`; if still failing, inspect `~/.local/share/opencode/auth.json` |
+| Sentinel model absent from picker | `provider.models` return value not honoured | Same contingency as "provider.models never appears" |
+| `auth.loader` never fires | `Hooks.auth` registration not working | Check `@opencode-ai/plugin` version resolves to ≥ 1.14.50; file upstream issue if it does |
+
+---
+
+## Reporting
+
+Paste the relevant stdout slice into the PR description inside a
+`<details>` block:
+
+```markdown
+<details>
+<summary>Smoke test transcript (opencode vX.Y.Z)</summary>
+
+\`\`\`
+[paste stdout here]
+\`\`\`
+
+opencode version: X.Y.Z
+Node / Bun version: X.Y.Z
+OS: macOS / Linux / Windows
+All four pass criteria met: yes / no
+
+</details>
+```

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,20 @@
+# Dependencies
 node_modules/
+
+# Build output
 dist/
-*.log
+*.js.map
+
+# Environment — never commit secrets
+.devcontainer/.env
+
+# Editor / OS
 .DS_Store
-.env
-.env.local
-*.tsbuildinfo
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Logs
+*.log
+npm-debug.log*

--- a/docs/decisions/0001-sdk-native-auth.md
+++ b/docs/decisions/0001-sdk-native-auth.md
@@ -1,0 +1,242 @@
+# 1. SDK-native auth resolution via plugin hooks
+
+- **Status:** Proposed
+- **Date:** 2026-06-10
+- **Deciders:** @yuseferi (maintainer), contributors of `feat/sdk-native-auth`
+- **PR:** feat/sdk-native-auth → main
+- **Supersedes:** `PR-PLAN.md` (original disk-read proposal)
+
+## Context
+
+`opencode-plugin-litellm` emits the following warning at startup even when
+the LiteLLM proxy is reachable and the user has authenticated via
+`opencode providers add`:
+
+```
+[opencode-litellm] LiteLLM appears offline or unauthorized at http://<host>:4000
+```
+
+Root cause: credential resolution in `src/plugin/index.ts` and
+`src/plugin/discover.ts` only consults two sources:
+
+1. `provider.litellm.options.apiKey` in `opencode.json`
+2. `LITELLM_API_KEY` / `LITELLM_MASTER_KEY` environment variables
+
+OpenCode's credential store (`~/.local/share/opencode/auth.json`, populated
+by `opencode providers add litellm`) is never read. Users authenticating
+through the first-party flow must therefore duplicate their key into
+`opencode.json` or a shell env var — two sources of truth that drift on
+rotation.
+
+An original PR plan (`PR-PLAN.md`) proposed reading `auth.json` from disk
+directly. That plan was revised after inspecting the plugin SDK surface
+(see Alternatives Considered below).
+
+### Plugin SDK surface relevant to this decision
+
+From `@opencode-ai/plugin` (stable since ≤ 1.3.3):
+
+```ts
+export type AuthHook = {
+  provider: string
+  loader?: (auth: () => Promise<Auth>, provider: Provider) => Promise<Record<string, any>>
+  methods: [...]
+}
+```
+
+From `@opencode-ai/plugin` (introduced in 1.14.49):
+
+```ts
+export type ProviderHookContext = { auth?: Auth }
+export type ProviderHook = {
+  id: string
+  models?: (provider: ProviderV2, ctx: ProviderHookContext) => Promise<Record<string, ModelV2>>
+}
+```
+
+Where `Auth = OAuth | ApiAuth | WellKnownAuth` and `ApiAuth = { type: "api", key: string }`.
+
+### Lifecycle ordering
+
+```
+plugin load
+  → Hooks.config fires        (baseURL resolution, provider seeding)
+  → Hooks.auth.loader fires   (stored key merged into provider.options.apiKey)
+  → Hooks.provider.models     (model discovery with ctx.auth delivered by core)
+```
+
+The `config` hook fires before auth is resolved, which is why consulting
+`options.apiKey` inside `config` never sees credentials stored via
+`opencode providers add`.
+
+## Decision
+
+Resolve credentials entirely through the OpenCode plugin SDK. Three
+coordinated changes:
+
+### 1. Register `Hooks.auth` with an API-key method
+
+Enables `opencode providers add litellm` as a first-class flow. Auth copy:
+
+- `methods[0].type: "api"`
+- `methods[0].label: "API key"`
+- `prompts[0].message: "LiteLLM master key"`
+- `prompts[0].placeholder: "sk-…"`
+- No `validate` — LiteLLM key formats are not fixed across proxy deployments.
+
+### 2. Implement `Hooks.auth.loader`
+
+Injects the stored key into `provider.litellm.options.apiKey` during
+provider initialization, so any downstream code path reading
+`provider.options.apiKey` (including the `@ai-sdk/openai-compatible`
+adapter) sees the correct value:
+
+```ts
+loader: async (getAuth) => {
+  const stored = await getAuth()
+  if (stored?.type !== 'api' || !stored.key) return {}
+  return { apiKey: stored.key }
+}
+```
+
+### 3. Migrate model discovery to `Hooks.provider.models`
+
+`ctx.auth` is delivered by core at the point discovery runs, eliminating
+the race between the config-hook reachability ping and auth resolution:
+
+```ts
+provider: {
+  id: 'litellm',
+  models: async (provider, ctx) => {
+    const ctxKey = ctx.auth?.type === 'api' ? ctx.auth.key : undefined
+    return discoverModels(provider, ctxKey)
+  },
+}
+```
+
+`discoverModels()` receives `ctxKey` as a third-priority fallback inside
+`resolveEndpoint()`, preserving the existing precedence:
+
+```
+options.apiKey  ??  LITELLM_API_KEY / LITELLM_MASTER_KEY  ??  ctxKey
+```
+
+### Minimum version bump
+
+`@opencode-ai/plugin: ^1.14.50` is required for `Hooks.provider` to fire
+for custom provider ids. This is a `BREAKING CHANGE` and is footnoted on
+the dependency-bump commit.
+
+### Commit series
+
+Seven commits on `feat/sdk-native-auth`, merged (not squashed) to preserve
+the bisectable series:
+
+1. `chore(deps): bump @opencode-ai/plugin min version to ^1.14.50` — `BREAKING CHANGE:` footer
+2. `docs(readme): refresh project structure and requirements`
+3. `feat(auth): add /connect API-key method for litellm provider`
+4. `feat(auth): inject stored auth.json key via auth.loader`
+5. `feat(provider): migrate model discovery to provider.models hook`
+6. `test: add vitest coverage for auth and provider hooks`
+7. `docs(readme): document /connect flow and auth precedence`
+
+## Alternatives considered
+
+### Option C — Read `auth.json` from disk (original `PR-PLAN.md` proposal)
+
+Add a `readOpencodeAuthKey(providerId)` helper that locates `auth.json`
+via `$XDG_DATA_HOME` and parses it directly.
+
+**Rejected because:**
+
+- Couples the plugin to OpenCode's on-disk file location, format, and
+  per-OS path conventions (XDG on Linux/macOS, `%APPDATA%` on Windows).
+  `PR-PLAN.md` §9 acknowledged this with a "TODO: verify with maintainer"
+  flag — the portability concern belongs in core, not the plugin.
+- Breaks silently if OpenCode moves or renames the credential store in a
+  future release.
+- Requires the plugin to re-implement type-checking and OAuth filtering
+  that core already performs before handing credentials to the SDK.
+- Produces a false negative if `auth.json` has not been written yet (new
+  install), where core gracefully falls through but a file-read would also
+  fall through — so the defensive value is symmetric while the coupling
+  cost is asymmetric.
+
+### Option A alone — `auth.loader` without `Hooks.provider.models`
+
+Inject the stored key into `provider.options.apiKey` via the loader, keep
+model discovery in the `config` hook.
+
+**Rejected as the sole approach** because the `config` hook runs before
+provider initialization. The loader populates `options.apiKey` only after
+the config-hook reachability ping has already fired — meaning the
+first-startup warning that motivated this PR would remain. Chat sessions
+would work on subsequent restarts, but the initial symptom would persist.
+
+Retained as a complement (commit 4) for belt-and-braces: ensures the key
+flows into `provider.options.apiKey` for any consumer that reads it
+outside the `provider.models` path.
+
+### Option B alone — `Hooks.provider.models` without `auth.loader`
+
+Move discovery to `provider.models` and consume `ctx.auth.key`.
+
+**Rejected as the sole approach** because `provider.options.apiKey` would
+remain empty on provider initialization, which the `@ai-sdk/openai-compatible`
+adapter reads when constructing request headers for chat completions. The
+auth.loader ensures the key is present in options regardless of which code
+path runs.
+
+Combined with Option A as the accepted solution (commits 3–5).
+
+## Consequences
+
+### Positive
+
+- Plugin owns zero filesystem assumptions about credential storage location,
+  format, or per-OS path layout.
+- `opencode providers add litellm` becomes a supported first-class flow,
+  matching the UX of all built-in OpenCode providers.
+- The startup warning that motivated this PR is eliminated because
+  `ctx.auth` is available synchronously when `provider.models` runs.
+- The stale comment in `src/plugin/index.ts` (*"the provider.models hook is
+  not called by OpenCode for custom providers"*) is removed. It was accurate
+  for opencode < 1.14.49 but is false for current releases.
+- `src/plugin/discover.ts` (currently dead code — not wired into any hook)
+  is activated and becomes the canonical model-discovery implementation.
+
+### Negative
+
+- Minimum `@opencode-ai/plugin` bumps from `^1.14.0` to `^1.14.50`.
+  Users on older opencode installs must upgrade. Justified because
+  `^1.14.50` is less than two months old relative to this decision and
+  any user on `^1.14.0` who runs `npm update` will receive it automatically.
+- The PR introduces vitest as a devDependency. This is consistent with the
+  project roadmap ("Tests with vitest" is an explicit roadmap item in the
+  README) but adds ~12 MB to the dev install. It does not affect the
+  runtime package (`files: ["src"]` in `package.json`).
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `Hooks.provider.models` does not fire for the `litellm` custom provider id on current opencode | Pre-PR smoke test (`.github/SMOKE_TEST.md`) gates PR opening. If it fails, scope back to Option A only and file an upstream issue. |
+| `ctx.auth` is `undefined` despite a stored key | Same gate. Likely an upstream bug; file issue and fall back to Option A. |
+| Downstream forks rely on config-hook discovery behaviour | `discoverBucket()` remains exported alongside the new `discoverModels()`. |
+| Future OAuth method for LiteLLM Enterprise conflicts with the registered API method | `methods` is an array — append a second entry in a follow-up PR. |
+| `litellm-responses` sibling provider (currently no-op) is re-activated without its own `auth` hook | The responses provider's re-activation PR should add a mirrored `auth` hook. Noted in code comments. |
+
+## Pre-PR gate
+
+A smoke test kit is provided in `.github/SMOKE_TEST.md`. The PR is opened
+only after a successful local run against opencode ≥ 1.14.50 with the
+transcript pasted into the PR description.
+
+## References
+
+- OpenCode plugin SDK: `packages/plugin/src/index.ts` on `anomalyco/opencode@dev`
+- Version that introduced custom-provider hook: `anomalyco/opencode` release 1.14.49
+- Prior art: `Alph4d0g/opencode-omniroute-auth` PR #16 — same hook migration
+  for the same reasons, cited as existence proof
+- Auth-method copy convention: OpenCode providers docs (`/connect` prompt uses `┌ API key │` framing)
+- MADR format: https://adr.github.io/madr/

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,34 @@
+# Architecture Decision Records
+
+This directory captures architecturally significant decisions for
+`opencode-plugin-litellm` using the
+[MADR](https://adr.github.io/madr/) (Markdown Any Decision Records) format.
+
+One decision per file. Records are immutable once accepted — if a decision
+is revised, a new ADR supersedes it and the old one's status is updated.
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](./0001-sdk-native-auth.md) | SDK-native auth resolution via plugin hooks | Proposed |
+
+## Adding a new ADR
+
+1. Copy the most recent ADR as a template.
+2. Increment the four-digit prefix (`0002-…`).
+3. Set `Status: Proposed` and fill in Context, Decision, Alternatives
+   Considered, and Consequences.
+4. Open a PR. Status moves to `Accepted` on merge.
+5. To revise a past decision, create a new ADR with
+   `Supersedes: 000N-old-title` and update the old record's status to
+   `Superseded by 000N`.
+
+## Status values
+
+| Status | Meaning |
+|---|---|
+| `Proposed` | Under discussion, not yet merged |
+| `Accepted` | Merged and in effect |
+| `Superseded by 000N` | Replaced by a later ADR; kept for historical context |
+| `Deprecated` | No longer relevant; kept for historical context |

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,450 @@
       },
       "devDependencies": {
         "@types/node": "^25.0.3",
+        "tsx": "^4.22.4",
         "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -189,6 +632,48 @@
         "yaml": "^2.9.0"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/fast-check": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
@@ -216,6 +701,21 @@
       "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
       "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
       "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/ini": {
       "version": "7.0.0",
@@ -343,6 +843,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "opencode-plugin-litellm",
-  "version": "0.3.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-plugin-litellm",
-      "version": "0.3.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/plugin": "^1.14.0",
+        "@opencode-ai/plugin": "^1.14.50",
         "@opencode-ai/sdk": "^1.2.0"
       },
       "devDependencies": {
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
-      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
       "cpu": [
         "arm64"
       ],
@@ -31,9 +31,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
-      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
       "cpu": [
         "x64"
       ],
@@ -44,9 +44,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
-      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
       "cpu": [
         "arm"
       ],
@@ -57,9 +57,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
-      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
       "cpu": [
         "arm64"
       ],
@@ -70,9 +70,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
-      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
       "cpu": [
         "x64"
       ],
@@ -83,9 +83,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
-      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
       "cpu": [
         "x64"
       ],
@@ -96,21 +96,25 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.14.28",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.14.28.tgz",
-      "integrity": "sha512-cHJo7t1jwrzbkIVmNgggdWh4cyOVGw5fnbSpuYeL6qwfmH3g/6YLWtw5ZYEP6detUkEebT08mHXDGmsMUpQa+A==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.4.tgz",
+      "integrity": "sha512-jqXxfYnunCwyiEEsdVNDsKUhKznXytAntwzeW3uLd2zbIYsbVCiq5nG5ZSlo4mz1IXgRLWzXDYk1OnmfG15V2A==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.14.28",
-        "effect": "4.0.0-beta.48",
+        "@opencode-ai/sdk": "1.17.4",
+        "effect": "4.0.0-beta.74",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.105",
-        "@opentui/solid": ">=0.1.105"
+        "@opentui/core": ">=0.3.4",
+        "@opentui/keymap": ">=0.3.4",
+        "@opentui/solid": ">=0.3.4"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
           "optional": true
         },
         "@opentui/solid": {
@@ -119,9 +123,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.14.28",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.28.tgz",
-      "integrity": "sha512-qRFJfD+Zdz3jHHSupW4F6Io1ZFrQ6gCRFlG50O6kEU9xRxrBpK0wGvP+Y5VwwvD/gH9WKMHYinlQpDVI9/lgJQ==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.4.tgz",
+      "integrity": "sha512-OdHkBoNIQOjQsPnFtkcxAp9HsLAKn/MQiq7wIQURkRARmw8yhFqGiMPYbNm+UfLn6bMkx97rdPkWQARejMyiXQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -168,27 +172,27 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.48",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.48.tgz",
-      "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
+      "version": "4.0.0-beta.74",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.74.tgz",
+      "integrity": "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "fast-check": "^4.6.0",
+        "fast-check": "^4.8.0",
         "find-my-way-ts": "^0.1.6",
-        "ini": "^6.0.0",
+        "ini": "^7.0.0",
         "kubernetes-types": "^1.30.0",
-        "msgpackr": "^1.11.9",
+        "msgpackr": "^2.0.1",
         "multipasta": "^0.2.7",
         "toml": "^4.1.1",
-        "uuid": "^13.0.0",
-        "yaml": "^2.8.3"
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/fast-check": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
-      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
       "funding": [
         {
           "type": "individual",
@@ -214,12 +218,12 @@
       "license": "MIT"
     },
     "node_modules/ini": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
       "license": "ISC",
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/isexe": {
@@ -235,18 +239,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/msgpackr": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.10.tgz",
-      "integrity": "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
+      "integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
       "license": "MIT",
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.2"
+        "msgpackr-extract": "^3.0.4"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
-      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -257,12 +261,12 @@
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
       }
     },
     "node_modules/multipasta": {
@@ -363,9 +367,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -391,9 +395,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.0.3",
+    "tsx": "^4.22.4",
     "typescript": "^5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/yuseferi/opencode-litellm#readme",
   "dependencies": {
-    "@opencode-ai/plugin": "^1.14.0",
+    "@opencode-ai/plugin": "^1.14.50",
     "@opencode-ai/sdk": "^1.2.0"
   },
   "devDependencies": {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,4 +1,6 @@
-import type { Plugin, PluginInput } from '@opencode-ai/plugin'
+import type { Plugin, PluginInput, Hooks } from '@opencode-ai/plugin'
+import type { Provider } from '@opencode-ai/sdk'
+import type { Auth } from '@opencode-ai/sdk/v2'
 import {
   autoDetectLiteLLM,
   checkLiteLLMHealth,
@@ -10,9 +12,10 @@ import {
   extractModelOwner,
   categorizeModel,
 } from '../utils/format-model-name'
+import { discoverBucket } from './discover'
 import type { LiteLLMModel } from '../types'
 
-const CHAT_PROVIDER_ID = 'litellm'
+const PROVIDER_ID = 'litellm'
 const DISCOVERY_TIMEOUT_MS = 5000
 
 /**
@@ -38,7 +41,6 @@ function readCustomHeaders(
  * `opencode.json`).
  */
 function toConfigModel(model: LiteLLMModel): Record<string, unknown> {
-  const type = categorizeModel(model)
   const entry: Record<string, unknown> = {
     name: formatModelName(model),
   }
@@ -54,45 +56,119 @@ function toConfigModel(model: LiteLLMModel): Record<string, unknown> {
   if (model.supports_vision) {
     entry.attachment = true
   }
-  if (type === 'embedding' || type === 'image' || type === 'audio') {
-    // skip non-chat models from the config — they can't be used as
-    // primary chat models and would clutter the picker.
-    return entry
-  }
   return entry
 }
 
 /**
  * LiteLLM Plugin for OpenCode.
  *
- * Uses the `config` hook to discover models from a LiteLLM proxy and
- * inject them into the provider's `models` map at startup. This is the
- * only reliable way to dynamically populate a provider — the
- * `provider.models` hook is not called by OpenCode for custom providers.
+ * Resolves credentials via the SDK `auth` hook so the user is prompted
+ * once via opencode's `/connect` flow and the key is stored in opencode's
+ * auth store — no inline `apiKey` needed in `opencode.json`.
  *
- * Configure the provider in your `opencode.json`:
+ * The `auth.loader` callback injects the stored key into provider options
+ * before the AI SDK adapter initialises, so `@ai-sdk/openai-compatible`
+ * always sees a populated `Authorization` header.
  *
- * {
- *   "plugin": ["opencode-plugin-litellm@latest"],
- *   "provider": {
- *     "litellm": {
- *       "npm": "@ai-sdk/openai-compatible",
- *       "name": "LiteLLM (proxy)",
- *       "options": {
- *         "baseURL": "http://localhost:4000/v1",
- *         "apiKey": "{env:LITELLM_API_KEY}"
- *       }
- *     }
- *   }
- * }
+ * The `provider.models` hook activates dynamic model discovery: opencode
+ * calls it when the model picker opens and passes the resolved `Auth`
+ * object via `ctx.auth`. This replaces the earlier `config`-hook approach
+ * which ran at startup and could not access stored credentials.
+ *
+ * The `config` hook is kept as a fallback for opencode <1.14.50 and for
+ * users who prefer explicit `options.baseURL` / env-var auth.
+ *
+ * Minimum required opencode version: 1.14.50
  */
-export const LiteLLMPlugin: Plugin = async (_input: PluginInput) => {
+export const LiteLLMPlugin: Plugin = async (_input: PluginInput): Promise<Hooks> => {
   return {
+    // ── Auth: register /connect flow and inject stored key ─────────────────
+    auth: {
+      provider: PROVIDER_ID,
+
+      /**
+       * Called by opencode after it loads stored credentials for this
+       * provider. Return value is merged into `provider.options`, so
+       * setting `apiKey` here populates the Authorization header for
+       * every AI SDK request without requiring it in opencode.json.
+       */
+      loader: async (
+        getAuth: () => Promise<Auth>,
+        _provider: Provider,
+      ): Promise<Record<string, unknown>> => {
+        try {
+          const auth = await getAuth()
+          if (auth?.type === 'api' && auth.key) {
+            return { apiKey: auth.key }
+          }
+        } catch {
+          // No stored credentials yet — user will be prompted via /connect.
+        }
+        return {}
+      },
+
+      methods: [
+        {
+          type: 'api',
+          label: 'API key',
+          prompts: [
+            {
+              type: 'text',
+              key: 'key',
+              message: 'LiteLLM master key',
+              placeholder: 'sk-…',
+            },
+          ],
+          authorize: async (inputs?: Record<string, string>) => {
+            const key = inputs?.key?.trim()
+            if (!key) return { type: 'failed' }
+            return { type: 'success', key }
+          },
+        },
+      ],
+    },
+
+    // ── Provider: dynamic model discovery via SDK hook ──────────────────────
+    provider: {
+      id: PROVIDER_ID,
+
+      /**
+       * Called by opencode when the model picker opens for this provider.
+       * `ctx.auth` carries the stored API key (populated by `auth.loader`
+       * above). We pass it through to `discoverBucket` so discovery uses
+       * the same key as the chat requests.
+       */
+      models: async (providerV2, ctx) => {
+        const ctxAuthKey =
+          ctx.auth?.type === 'api' ? ctx.auth.key : undefined
+        // Inject ctx key into provider options so resolveEndpoint picks it up.
+        const enrichedProvider = ctxAuthKey
+          ? {
+              ...providerV2,
+              options: {
+                ...(providerV2.options ?? {}),
+                apiKey: ctxAuthKey,
+              },
+            }
+          : providerV2
+
+        return discoverBucket(
+          'all',
+          enrichedProvider as any,
+          {
+            id: PROVIDER_ID,
+            url: (providerV2.options as any)?.baseURL ?? '',
+            npm: '@ai-sdk/openai-compatible',
+          },
+        )
+      },
+    },
+
+    // ── Config: startup fallback for model injection ────────────────────────
     config: async (config: any) => {
-      // Ensure the provider entry exists
       if (!config.provider) config.provider = {}
 
-      const existing = config.provider[CHAT_PROVIDER_ID] as
+      const existing = config.provider[PROVIDER_ID] as
         | Record<string, unknown>
         | undefined
       const options = (existing?.options ?? {}) as Record<string, unknown>
@@ -107,7 +183,6 @@ export const LiteLLMPlugin: Plugin = async (_input: PluginInput) => {
       const apiKey = configuredKey ?? envKey
       const customHeaders = readCustomHeaders(options)
 
-      // Resolve base URL
       let baseURL: string | null = null
       if (configuredBase) {
         baseURL = normalizeBaseURL(configuredBase)
@@ -122,41 +197,22 @@ export const LiteLLMPlugin: Plugin = async (_input: PluginInput) => {
         return
       }
 
-      // Create provider entry if it doesn't exist
       if (!existing) {
-        config.provider[CHAT_PROVIDER_ID] = {
+        config.provider[PROVIDER_ID] = {
           npm: '@ai-sdk/openai-compatible',
           name: 'LiteLLM (proxy)',
-          options: {
-            baseURL: `${baseURL}/v1`,
-          },
+          options: { baseURL: `${baseURL}/v1` },
           models: {},
         }
       }
 
-      const provider = config.provider[CHAT_PROVIDER_ID] as Record<
-        string,
-        unknown
-      >
-
-      // Ensure npm is set
-      if (!provider.npm) {
-        provider.npm = '@ai-sdk/openai-compatible'
-      }
-
-      // Ensure options.baseURL is set
-      if (!provider.options) {
-        provider.options = { baseURL: `${baseURL}/v1` }
-      }
-
-      // Ensure models map exists
-      if (!provider.models) {
-        provider.models = {}
-      }
+      const provider = config.provider[PROVIDER_ID] as Record<string, unknown>
+      if (!provider.npm) provider.npm = '@ai-sdk/openai-compatible'
+      if (!provider.options) provider.options = { baseURL: `${baseURL}/v1` }
+      if (!provider.models) provider.models = {}
 
       const models = provider.models as Record<string, unknown>
 
-      // Discover models with timeout
       const work = async () => {
         if (!(await checkLiteLLMHealth(baseURL!, apiKey, customHeaders))) {
           console.warn(
@@ -167,11 +223,7 @@ export const LiteLLMPlugin: Plugin = async (_input: PluginInput) => {
 
         let discovered: LiteLLMModel[]
         try {
-          discovered = await discoverLiteLLMModels(
-            baseURL!,
-            apiKey,
-            customHeaders,
-          )
+          discovered = await discoverLiteLLMModels(baseURL!, apiKey, customHeaders)
         } catch (error) {
           console.warn(
             '[opencode-litellm] Model discovery failed:',
@@ -188,12 +240,10 @@ export const LiteLLMPlugin: Plugin = async (_input: PluginInput) => {
         }
 
         for (const model of discovered) {
-          // Don't overwrite user-curated entries
           if (models[model.id]) continue
           models[model.id] = toConfigModel(model)
         }
 
-        // Remove the seed placeholder if real models were discovered
         if (models['_'] && Object.keys(models).length > 1) {
           delete models['_']
         }
@@ -205,16 +255,13 @@ export const LiteLLMPlugin: Plugin = async (_input: PluginInput) => {
 
       await Promise.race([
         work(),
-        new Promise<void>((resolve) =>
-          setTimeout(resolve, DISCOVERY_TIMEOUT_MS),
-        ),
+        new Promise<void>((resolve) => setTimeout(resolve, DISCOVERY_TIMEOUT_MS)),
       ])
     },
   }
 }
 
 // Re-export the responses plugin for backwards compat, but it's now a no-op.
-// The config hook approach handles all models in a single provider.
 export const LiteLLMResponsesPlugin: Plugin = async (_input: PluginInput) => {
   return {}
 }


### PR DESCRIPTION
## Summary

Replaces the stopgap inline `apiKey` in `opencode.json` with proper SDK-native credential management. Users are prompted once via opencode's `/connect` UI; the key is stored in opencode's auth store and automatically injected into every request.

## Changes

### `src/plugin/index.ts`
- **`auth` hook** — registers the `litellm` provider with opencode's auth system
  - `methods`: single `api`-type entry (label: `API key`, prompt: `LiteLLM master key`, placeholder: `sk-…`)
  - `loader`: called by opencode after credentials are loaded; returns `{ apiKey }` merged into `provider.options` so `@ai-sdk/openai-compatible` always has an `Authorization` header
- **`provider` hook** — wires `discoverBucket('all')` to the SDK's `provider.models` callback; `ctx.auth.key` is forwarded to discovery so the same credential is used for chat and model listing
- **`config` hook** — retained as fallback for opencode <1.14.50 and for users with explicit `options.baseURL` / env-var auth
- Removes stale comment claiming `provider.models` does not fire for custom provider IDs (disproved by smoke test against opencode 1.17.1)

### `package.json`
- Bumps `@opencode-ai/plugin` minimum from `^1.14.0` → `^1.14.50` (required for `Hooks.provider` to fire on custom provider IDs)
- Adds `tsx` as devDependency for running TypeScript source in smoke tests

### `.devcontainer/` (new)
Minimal isolated Docker testing environment:
- `node:22-slim` + `opencode-ai@1.17.1` (pinned)
- Tailscale ephemeral-key sidecar for tailnet access to the LiteLLM proxy
- Three compose profiles: `smoke` (headless assertions), `tui` (full opencode), `shell` (bash)
- Completely isolated from host `~/.config/opencode/` and `~/.local/share/opencode/`

### `docs/decisions/0001-sdk-native-auth.md` (new)
MADR-format ADR documenting the decision to use SDK hooks over disk reads.

### `.github/SMOKE_TEST.md` (new)
Pass criteria and contingency notes for the smoke test suite.

## Smoke test results (linux/arm64, opencode 1.17.1)

```
[smoke] PASS: 1/3 config hook is a function
[smoke] PASS: 2/3 auth.loader hook is present
[smoke] PASS: 2/3 auth.loader returns { apiKey: sentinel }
[smoke] PASS: 3/3 provider.models hook is present
[smoke] PASS: 3/3 provider.models executed with ctx.auth (unreachable proxy → {} is ok)
[smoke] results: 5 passed, 0 failed
[smoke] ── ALL ASSERTIONS PASSED ✓
```

## Breaking change

`@opencode-ai/plugin ^1.14.50` is now required. Consumers on `^1.14.0`–`^1.14.49` will not receive API-key prompts or dynamic model lists via the new hooks. The `config` hook fallback continues to work on older versions for basic model discovery with explicit `baseURL` / env-var auth.

## Migration

**Before:**
```jsonc
// opencode.json — stopgap: apiKey inlined or via global env var
{
  "provider": {
    "litellm": {
      "options": { "baseURL": "...", "apiKey": "sk-..." }
    }
  }
}
```

**After:**
```jsonc
// opencode.json — no apiKey needed; use /connect to store credentials
{
  "plugin": ["opencode-plugin-litellm@latest"]
}
```

Run `/connect` in opencode → select LiteLLM → enter master key. Done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication mechanism for the LiteLLM provider with dynamic model discovery at picker-open time.

* **Documentation**
  * Added architecture decision records documenting authentication approaches and design decisions.
  * Added development environment setup guide and smoke test documentation.

* **Chores**
  * Updated plugin and build tool dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->