### PR TITLE
feat(plugin): fall back to OpenCode-stored /connect credentials for plugin auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **plugin:** surface reasoning-effort variants from `/v1/model/info` reported by LiteLLM
 
 ### Fixed
+- **LiteLLM model discovery now works when the proxy credential was only
+  ever stored via OpenCode's `/connect` command.** The plugin's health
+  check and `/v1/models` / `/v1/model/info` discovery fetches only ever
+  read `options.apiKey` or the `LITELLM_API_KEY` / `LITELLM_MASTER_KEY`
+  env vars. Credentials added through `/connect` (stored in
+  `~/.local/share/opencode/auth.json`) were invisible to them, and for
+  this custom provider OpenCode does not inject stored credentials
+  automatically, so a key-only proxy would fail the health check with
+  an unauthenticated 401, skip discovery entirely, and send chat
+  completions without an `Authorization` header. The plugin now falls
+  back to reading that stored credential and writes the resolved key
+  back into the provider `options`, enabling both authenticated
+  discovery and authenticated completions (precedence: configured
+  `apiKey` > env var > OpenCode-stored credential).
 - **Discovered models now carry real pricing instead of always showing
   `$0.00`.** `toConfigModel()` never read `input_cost_per_token` /
   `output_cost_per_token` from `/v1/model/info`, so every model —

--- a/README.md
+++ b/README.md
@@ -244,8 +244,9 @@ If your LiteLLM proxy requires a master key, expose it via either approach:
 | Env var | `export LITELLM_API_KEY=sk-...` |
 | Env var (alias) | `export LITELLM_MASTER_KEY=sk-...` |
 | Config | `"options": { "apiKey": "{env:LITELLM_API_KEY}" }` |
+| OpenCode `/connect` | Run `/connect`, search for your `litellm` provider entry, and paste the key |
 
-The env var path lets you commit `opencode.json` without leaking secrets.
+The env var path lets you commit `opencode.json` without leaking secrets. The `/connect` path is useful when you'd rather manage the credential through OpenCode's own auth store (`~/.local/share/opencode/auth.json`) instead of an env var or config file — the plugin reads that file as a fallback and applies the stored key to its own health-check, model-discovery, and completion-time provider requests, so a key-only proxy works end to end.
 
 ### Custom headers (Cloudflare Access, API gateways)
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -11,6 +11,7 @@ import {
   categorizeModel,
 } from '../utils/format-model-name'
 import type { LiteLLMModel, LiteLLMModelInfo } from '../types'
+import { getOpenCodeStoredApiKey } from '../utils/opencode-auth'
 
 const CHAT_PROVIDER_ID = 'litellm'
 // Covers the sequential 3 s health check plus the parallel 15 s
@@ -221,8 +222,17 @@ export const LiteLLMPlugin: Plugin = async (_input: PluginInput) => {
             ? options.apiKey
             : undefined
         const envKey =
-          process.env.LITELLM_API_KEY ?? process.env.LITELLM_MASTER_KEY
-        const apiKey = configuredKey ?? envKey
+          process.env.LITELLM_API_KEY || process.env.LITELLM_MASTER_KEY || undefined
+        /*
+        Falls back to the key OpenCode itself stored for this provider id via
+        '/connect' (~/.local/share/opencode/auth.json). For a custom provider
+        like this one there is no automatic auth.json injection (see below), so
+        the plugin reads the stored key here and applies it to both its own
+        discovery fetches and the completion-time provider options. Without it,
+        a key-only proxy would fail discovery even though chat works.
+        */
+        const storedKey = await getOpenCodeStoredApiKey(providerId)
+        const apiKey = configuredKey ?? envKey ?? storedKey
         const customHeaders = readCustomHeaders(options)
 
         // Resolve base URL
@@ -251,12 +261,25 @@ export const LiteLLMPlugin: Plugin = async (_input: PluginInput) => {
         }
 
         if (!actualProvider.options) {
-          actualProvider.options = { baseURL: `${baseURL}/v1` }
-        } else {
-          const actualOptions = actualProvider.options as Record<string, unknown>
-          if (!actualOptions.baseURL) {
-            actualOptions.baseURL = `${baseURL}/v1`
-          }
+          actualProvider.options = {}
+        }
+        const actualOptions = actualProvider.options as Record<string, unknown>
+        if (!actualOptions.baseURL) {
+          actualOptions.baseURL = `${baseURL}/v1`
+        }
+        /*
+        For a fully custom, config-only provider like this one, OpenCode
+        builds the real completion-time AI SDK client straight from
+        `options` - there's no separate auth.json auto-injection for
+        arbitrary custom providers (that only applies to a handful of
+        models.dev-catalog providers with special-cased loaders). So the
+        `apiKey` resolved above (config > env var > OpenCode-stored
+        credential) must be written back here, or real chat completions
+        go out with no Authorization header even though discovery
+        succeeded using the same resolved key.
+        */
+        if (!actualOptions.apiKey && apiKey) {
+          actualOptions.apiKey = apiKey
         }
 
         if (!actualProvider.models) {

--- a/src/utils/opencode-auth.ts
+++ b/src/utils/opencode-auth.ts
@@ -1,0 +1,83 @@
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Shape of an `api`-type entry in OpenCode's own credential store. OpenCode
+ * also stores `oauth` and `wellknown` entries there, but LiteLLM proxies
+ * only ever use a plain API key, so that's the only variant we care about.
+ */
+interface OpenCodeApiAuthEntry {
+  type: 'api'
+  key: string
+  metadata?: Record<string, string>
+}
+
+type OpenCodeAuthEntry = OpenCodeApiAuthEntry | { type: string; [key: string]: unknown }
+type OpenCodeAuthFile = Record<string, OpenCodeAuthEntry>
+
+/**
+ * OpenCode stores credentials added via the `/connect` command (or
+ * `opencode auth login`) in this file, keyed by provider id. The location
+ * is fixed and identical across macOS, Linux, and Windows — see
+ * https://opencode.ai/docs/troubleshooting/#storage.
+ */
+function resolveAuthPath(): string {
+  return join(homedir(), '.local', 'share', 'opencode', 'auth.json')
+}
+
+// Read once per process. The `config` hook can fire multiple times per
+// run (see plugin/index.ts), and re-reading a credentials file from disk
+// on every invocation is both wasteful and unnecessary — a `/connect` run
+// mid-session wouldn't be picked up by the already-running plugin anyway
+// (model discovery itself is cached per baseURL for the same reason).
+let cachedAuthFile: Promise<OpenCodeAuthFile | null> | null = null
+
+async function loadOpenCodeAuthFile(): Promise<OpenCodeAuthFile | null> {
+  if (!cachedAuthFile) {
+    cachedAuthFile = (async () => {
+      try {
+        const raw = await readFile(resolveAuthPath(), 'utf-8')
+        const parsed: unknown = JSON.parse(raw)
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          return parsed as OpenCodeAuthFile
+        }
+      } catch {
+        // File doesn't exist, isn't readable, or isn't valid JSON — treat
+        // as "no stored credentials" rather than failing plugin startup.
+      }
+      return null
+    })()
+  }
+  return cachedAuthFile
+}
+
+/**
+ * Look up the API key OpenCode itself stored for a given provider id via
+ * the `/connect` command. This is entirely separate from this plugin's
+ * own `options.apiKey` / `LITELLM_API_KEY` / `LITELLM_MASTER_KEY`
+ * configuration: for a custom provider like this one, OpenCode does not
+ * inject stored credentials automatically, so the plugin reads the file
+ * directly and applies the key to its own health-check / `/v1/models`
+ * discovery fetches and to the completion-time provider `options` (see
+ * plugin/index.ts) as a fallback credential source.
+ *
+ * Returns `undefined` if the file is missing/unreadable, or has no
+ * `type: "api"` entry for `providerId`.
+ */
+export async function getOpenCodeStoredApiKey(providerId: string): Promise<string | undefined> {
+  const auth = await loadOpenCodeAuthFile()
+  const entry = auth?.[providerId]
+  if (entry && entry.type === 'api' && typeof (entry as OpenCodeApiAuthEntry).key === 'string') {
+    const key = (entry as OpenCodeApiAuthEntry).key
+    if (key.length > 0) {
+      return key
+    }
+  }
+  return undefined
+}
+
+/** Test-only: force the next read to hit disk again. */
+export function __resetOpenCodeAuthCacheForTests(): void {
+  cachedAuthFile = null
+}


### PR DESCRIPTION
## Summary

The plugin's own health-check and `/v1/models` discovery fetches only ever read `options.apiKey` or the `LITELLM_API_KEY` / `LITELLM_MASTER_KEY` env vars, so a key stored via OpenCode's `/connect` command was invisible to them — a key-only proxy failed the health check with a 401 and silently skipped discovery. This PR makes the plugin fall back to that stored credential and writes the resolved key back into the provider `options` so real chat completions authenticate too. Closes https://github.com/yuseferi/opencode-litellm/issues/8.

## Type of change

- [ ] 🐛 Bug fix (non-breaking)
- [x] ✨ New feature (non-breaking)
- [ ] 💥 Breaking change
- [ ] 📝 Documentation only
- [ ] 🔧 Internal / refactor

## Checklist

- [x] `npm run typecheck` passes
- [x] No new runtime dependencies (or justified in this PR description)
- [x] README updated if public API or behavior changed
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## How was this tested?

Tested against a live remote LiteLLM deployment configured with a master key (no `options.apiKey` / env var set, credential added via OpenCode `/connect` only). OpenCode version: 1.18.16. LiteLLM version: N/A (remote deployment).

Representative log line:

```
[opencode-litellm] Discovered 97 models for provider "litellm" from https://redacted-endpoint (79 added, 17 non-chat hidden)
```

## Screenshots / logs (optional)

```
[opencode-litellm] Discovered 97 models for provider "litellm" from https://redacted-endpoint (79 added, 17 non-chat hidden)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenCode `/connect` credential support as a fallback for authentication.
  * Authenticated health checks, model discovery, and completion requests can use stored credentials when no configured or environment key is available.
  * Improved model discovery with cached results for faster startup and background refreshes when needed.

* **Documentation**
  * Updated authentication guidance to explain OpenCode credential setup and fallback behavior.
  * Added the change to the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->