### PR TITLE
feat: map LiteLLM model prices into OpenCode cost field

### DIFF
--- a/src/plugin/build-model.ts
+++ b/src/plugin/build-model.ts
@@ -54,9 +54,12 @@ export function buildModelV2(
       interleaved: false,
     },
     cost: {
-      input: 0,
-      output: 0,
-      cache: { read: 0, write: 0 },
+      input: info?.input_cost_per_token ?? 0,
+      output: info?.output_cost_per_token ?? 0,
+      cache: {
+        read: info?.cache_read_input_token_cost ?? 0,
+        write: info?.cache_creation_input_token_cost ?? 0,
+      },
     },
     limit: {
       context: model.max_input_tokens ?? 0,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,8 @@ export interface LiteLLMModelInfo {
   supports_audio_input?: boolean
   input_cost_per_token?: number
   output_cost_per_token?: number
+  cache_read_input_token_cost?: number
+  cache_creation_input_token_cost?: number
 }
 
 /** A single entry returned by LiteLLM's `/v1/model/info` endpoint. */


### PR DESCRIPTION
# PR Title
feat: map LiteLLM model prices into OpenCode cost field

# PR Body
## Problem
The plugin discovers models from `/v1/model/info` (which reliably carries `input_cost_per_token`, `output_cost_per_token`, and cache pricing), but `buildModelV2` currently hardcodes `cost.input`, `cost.output`, and `cost.cache` to `0`.

As a result, OpenCode falls back to its own internal price table for `spent` / cost tracking. For models like Azure-hosted DeepSeek V4 Pro, this fallback price is wrong, causing a large discrepancy between what OpenCode displays and what LiteLLM actually bills (e.g. $0.04 in OpenCode vs $0.29 in the LiteLLM dashboard).

## Fix
Populate `Model.cost` from the pricing metadata returned by LiteLLM instead of zeroing it:
- `cost.input` ← `info.input_cost_per_token`
- `cost.output` ← `info.output_cost_per_token`
- `cost.cache.read` ← `info.cache_read_input_token_cost`
- `cost.cache.write` ← `info.cache_creation_input_token_cost`

Also extends `LiteLLMModelInfo` with the two cache cost fields so TypeScript strict mode accepts them.

## Verification
- `npm run typecheck` passes.
- With this change, OpenCode's picker and `/cost` use the exact prices configured in the LiteLLM proxy, matching Azure retail pricing and the LiteLLM dashboard.

## Scope
No Terraform or infrastructure changes; this is purely a plugin-side fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model cost information now accurately includes input, output, cache read, and cache creation token costs when available.
  * Missing cost details safely default to zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->