### PR TITLE
fix: keep wildcard model aliases in discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Bug Fixes
+
+* keep trailing-wildcard model aliases (`claude-sonnet-4-6*`) in discovery; only `provider/*` wildcards are filtered out
+
 # [0.10.0](https://github.com/yuseferi/opencode-litellm/compare/v0.9.0...v0.10.0) (2026-08-26)
 
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -249,9 +249,10 @@ async function discoverModels(
   let wildcards = 0
   const unmatched: string[] = []
   for (const model of discovered) {
-    // Wildcard entries (`deepseek/*`) are access rules, not
-    // callable models — invoking one sends a literal `*` upstream.
-    if (model.id.includes('*')) {
+    // `deepseek/*` is an access rule, not a callable model. But a
+    // trailing `*` (`claude-sonnet-4-6*`) is a model-group alias,
+    // so only skip the `provider/*` form.
+    if (model.id.includes('/*')) {
       wildcards++
       continue
     }


### PR DESCRIPTION
## Summary

`model.id.includes('*')` was skipping every wildcard entry. Only `provider/*` wildcards (e.g. `deepseek/*`) are access rules; a trailing `*` on a bare model name (`claude-sonnet-4-6*`) is a callable LiteLLM model-group alias, so those models never showed up in the picker. This narrows the skip to the `provider/*` form.

## Type of change

- [x] 🐛 Bug fix (non-breaking)
- [ ] ✨ New feature (non-breaking)
- [ ] 💥 Breaking change
- [ ] 📝 Documentation only
- [ ] 🔧 Internal / refactor

## Checklist

- [x] `npm run typecheck` passes
- [x] No new runtime dependencies (or justified in this PR description)
- [x] README updated if public API or behavior changed
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## How was this tested?

Tested against LiteLLM 1.98.0 (self-hosted proxy) with the plugin run via a local `file://` load, using a model_list where Claude models are exposed as model-group aliases (`claude-haiku-4-5*`, `claude-opus-5*`, `claude-sonnet-4-6*`, …). Also verified a direct call to `/v1/chat/completions` with `model: "claude-sonnet-4-6*"` succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model aliases with trailing wildcards, such as `claude-sonnet-4-6*`, are now discoverable and callable.
  * Provider-wide wildcard entries remain excluded from model discovery.
* **Documentation**
  * Added an unreleased changelog entry describing the corrected wildcard handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->